### PR TITLE
Optimize contour lines (GL_LINE_STRIP) and remove duplicates

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -232,8 +232,11 @@ pub fn world_vertices(
             world_triangles_sphere.push(geo_triangle_to_sphere(triangle_2d));
         }
     }
-    for contour in world_contours {
-        world_contours_sphere.push(contour.into_iter().map(latlong2xyz).collect());
+    for mut contour_line in world_contours {
+        if subdivide {
+            contour_line = geo::subdivide_contour(&contour_line);
+        }
+        world_contours_sphere.push(contour_line.into_iter().map(latlong2xyz).collect());
     }
     log::info!(
         "Mapped {} 2D triangles onto {} 3D triangles on a sphere",


### PR DESCRIPTION
This PR does three things to the contour lines between geographical entities:

* Subdivide long contour edges just like we do with triangles. Makes long lines not take a shortcut through earth and end up not visible
* Removed duplicate contour line segments. Keep a `HashSet` with seen edges and skip already drawn edges
* Order the contour line index buffer so it can be drawn as a single continuous line with `GL_LINE_STRIP` instead of the current `GL_LINES`. This reduces the size of the `land_contour_indices.bin` file from `873 kb` bytes to `392 kb`.

If we had access to OpenGL 3.1 we could draw the line strips much nicer with a single draw call thanks to `glPrimitiveRestartIndex`. But sadly this is not available to us. Instead this uses a hack where we continue the continuous line by drawing underneath the earths crust to the new position and pop back up there.