### PR TITLE
Replace largest_angle hack with proper 2d->3d error function

### DIFF
--- a/src/geo.rs
+++ b/src/geo.rs
@@ -3,9 +3,12 @@ use shapefile::{Point, PolygonRing, Shape};
 use std::f32::consts::{PI, TAU};
 use std::hash::Hash;
 use std::path::Path;
+use vecmat::Vector;
 
-const MAX_COORDINATE_ANGLE_RAD_TRIANGLES: f32 = (5.0 / 180.0) * PI;
-const MAX_COORDINATE_ANGLE_RAD_CONTOURS: f32 = (1.0 / 180.0) * PI;
+use crate::linalg::Vertex;
+
+const MAX_TRIANGLE_CUT_THROUGH_SPHERE_ERROR: f32 = 0.001;
+const MAX_CONTOUR_CUT_THROUGH_SPHERE_ERROR: f32 = MAX_TRIANGLE_CUT_THROUGH_SPHERE_ERROR / 20.0;
 
 /// This is the data format `earcutr` expects. It's conceptually a list of rings.
 /// The first ring being the outer ring and any subsequent rings are inner rings.
@@ -64,8 +67,8 @@ pub fn subdivide_contour(contour: &[Coordinate]) -> Vec<Coordinate> {
     /// Returns a list of coordinates making up the line between c0 and c1 (excluding c1 itself)
     /// but split into small enough chunks.
     fn split_line(c0: Coordinate, c1: Coordinate) -> Vec<Coordinate> {
-        let largest_angle = largest_angle(c0, c1);
-        if largest_angle > MAX_COORDINATE_ANGLE_RAD_CONTOURS {
+        let line_error = error(c0, c1);
+        if line_error > MAX_CONTOUR_CUT_THROUGH_SPHERE_ERROR {
             let midpoint = midpoint(c0, c1);
             let mut output = split_line(c0, midpoint);
             output.extend(split_line(midpoint, c1));
@@ -98,22 +101,22 @@ pub fn subdivide_triangle(triangle: Triangle) -> Vec<Triangle> {
         return vec![triangle];
     }
 
-    let d01 = largest_angle(c0, c1);
-    let d12 = largest_angle(c1, c2);
-    let d20 = largest_angle(c2, c0);
+    let c0c1_error = error(c0, c1);
+    let c1c2_error = error(c1, c2);
+    let c2c0_error = error(c2, c0);
 
     let mut too_long_side = false;
-    if d01 > MAX_COORDINATE_ANGLE_RAD_TRIANGLES {
+    if c0c1_error > MAX_TRIANGLE_CUT_THROUGH_SPHERE_ERROR {
         too_long_side = true;
-        log::debug!("c0-c1 is too long: {d01}");
+        log::debug!("c0-c1 is too long: {c0c1_error}");
     }
-    if d12 > MAX_COORDINATE_ANGLE_RAD_TRIANGLES {
+    if c1c2_error > MAX_TRIANGLE_CUT_THROUGH_SPHERE_ERROR {
         too_long_side = true;
-        log::debug!("c1-c2 is too long: {d12}");
+        log::debug!("c1-c2 is too long: {c1c2_error}");
     }
-    if d20 > MAX_COORDINATE_ANGLE_RAD_TRIANGLES {
+    if c2c0_error > MAX_TRIANGLE_CUT_THROUGH_SPHERE_ERROR {
         too_long_side = true;
-        log::debug!("c2-c0 is too long: {d20}");
+        log::debug!("c2-c0 is too long: {c2c0_error}");
     }
     // Base case. Triangle is not large enough to need subdivision. Stop recursion.
     if !too_long_side {
@@ -122,13 +125,13 @@ pub fn subdivide_triangle(triangle: Triangle) -> Vec<Triangle> {
 
     // At least one edge is too long. Rotate it so that it has the longest
     // side furthes away from c0, to fit with `split_triangle`
-    let rotated_triangle = if d01 >= d12 && d01 >= d20 {
+    let rotated_triangle = if c0c1_error >= c1c2_error && c0c1_error >= c2c0_error {
         // The side between c0 and c1 is the longest
         Triangle::from([c2, c0, c1])
-    } else if d12 >= d20 && d12 >= d01 {
+    } else if c1c2_error >= c2c0_error && c1c2_error >= c0c1_error {
         // The side between c1 and c2 is the longest
         Triangle::from([c0, c1, c2])
-    } else if d20 >= d01 && d20 >= d12 {
+    } else if c2c0_error >= c0c1_error && c2c0_error >= c1c2_error {
         // The side between c2 and c0 is the longest
         Triangle::from([c1, c2, c0])
     } else {
@@ -144,20 +147,31 @@ pub fn subdivide_triangle(triangle: Triangle) -> Vec<Triangle> {
     output
 }
 
-/// Returns the largest of the lat or long angles between two
-/// coordinates. A rough estimate used to decide of i line needs
-/// to be subdivided before translated into 3D.
-fn largest_angle(c0: Coordinate, c1: Coordinate) -> f32 {
-    let d_lat = (c1.lat - c0.lat).abs();
+/// Returns how far from earth's surface the 3D line between these coordinates deviates.
+/// Since a line when translated to 3D should ideally follow the surface, if it
+/// deviates too far, it should be split into multiple segments to reduce the error.
+fn error(c0: Coordinate, c1: Coordinate) -> f32 {
+    let v0 = latlong2xyz(c0).to_vector();
+    let v1 = latlong2xyz(c1).to_vector();
 
-    let mut d_long = c1.long - c0.long;
-    if d_long > PI {
-        d_long -= TAU;
-    } else if d_long < -PI {
-        d_long += TAU;
-    }
+    let midpoint_through_globe = midpoint_3d(v0, v1);
+    let midpoint_on_globe = latlong2xyz(midpoint(c0, c1)).to_vector();
 
-    d_lat.max(d_long.abs())
+    (midpoint_on_globe - midpoint_through_globe).length()
+}
+
+/// Maps a geographical coordinate represented in radians onto a sphere
+/// with radius 1.0, and returns the 3D vector
+pub fn latlong2xyz(c: Coordinate) -> Vertex {
+    // Polar angle. 0 <= φ <= PI = colatitude in geography
+    let phi = (PI / 2.0) - c.lat;
+    // Azimuthal angle = longitude. -PI <= θ <= PI
+    let theta = c.long;
+
+    let x = phi.sin() * theta.sin();
+    let y = phi.cos();
+    let z = phi.sin() * theta.cos();
+    Vertex::from([x, y, z])
 }
 
 /// Splits a triangle into two. The edge that is cut into two is the one between c1 and c2.
@@ -171,6 +185,13 @@ fn split_triangle(triangle: Triangle) -> [Triangle; 2] {
     ]
 }
 
+/// Returns the 3D point halfway between v0 and v1.
+fn midpoint_3d(v0: Vector<f32, 3>, v1: Vector<f32, 3>) -> Vector<f32, 3> {
+    (v0 + v1) / 2.0
+}
+
+/// Returns the coordinate halfway between c0 and c1, taking the shortest
+/// route between the two.
 fn midpoint(mut c0: Coordinate, mut c1: Coordinate) -> Coordinate {
     clean_coordinate(&mut c0);
     clean_coordinate(&mut c1);
@@ -199,7 +220,7 @@ fn clean_coordinate(c: &mut Coordinate) {
 
 #[cfg(test)]
 mod tests {
-    use super::{midpoint, Coordinate};
+    use super::{latlong2xyz, midpoint, Coordinate};
 
     fn equal_float(f0: f32, f1: f32) -> bool {
         (f0 - f1).abs() <= crate::MIN_2D_POLAR_COORDINATE_ERROR
@@ -273,6 +294,55 @@ mod tests {
                 long: 180.0f32.to_radians(),
             },
         );
+    }
+
+    #[test]
+    fn latlong2xyz_sanity() {
+        let north_pole1 = geo::Coordinate {
+            lat: PI / 2.0,
+            long: 0.0,
+        };
+        let north_pole2 = geo::Coordinate {
+            lat: PI / 2.0,
+            long: PI / 1.2,
+        };
+        assert_eq!(latlong2xyz(north_pole1), Vertex::from([0.0, 1.0, 0.0]));
+        assert_eq!(latlong2xyz(north_pole2), Vertex::from([0.0, 1.0, 0.0]));
+
+        let south_pole1 = geo::Coordinate {
+            lat: -PI / 2.0,
+            long: 0.0,
+        };
+        let south_pole2 = geo::Coordinate {
+            lat: -PI / 2.0,
+            long: 0.1234,
+        };
+        assert_eq!(latlong2xyz(south_pole1), Vertex::from([0.0, -1.0, 0.0]));
+        assert_eq!(latlong2xyz(south_pole2), Vertex::from([0.0, -1.0, 0.0]));
+
+        let zero = geo::Coordinate {
+            lat: 0.0,
+            long: 0.0,
+        };
+        assert_eq!(latlong2xyz(zero), Vertex::from([0.0, 0.0, 1.0]));
+
+        let backside_equator = geo::Coordinate { lat: 0.0, long: PI };
+        assert_eq!(
+            latlong2xyz(backside_equator),
+            Vertex::from([0.0, 0.0, -1.0])
+        );
+
+        let to_the_right = geo::Coordinate {
+            lat: 0.0,
+            long: PI / 2.0,
+        };
+        assert_eq!(latlong2xyz(to_the_right), Vertex::from([1.0, 0.0, 0.0]));
+
+        let to_the_left = geo::Coordinate {
+            lat: 0.0,
+            long: -PI / 2.0,
+        };
+        assert_eq!(latlong2xyz(to_the_left), Vertex::from([-1.0, 0.0, 0.0]));
     }
 }
 

--- a/src/geo.rs
+++ b/src/geo.rs
@@ -154,10 +154,10 @@ fn error(c0: Coordinate, c1: Coordinate) -> f32 {
     let v0 = latlong2xyz(c0).to_vector();
     let v1 = latlong2xyz(c1).to_vector();
 
-    let midpoint_through_globe = midpoint_3d(v0, v1);
-    let midpoint_on_globe = latlong2xyz(midpoint(c0, c1)).to_vector();
+    let midpoint = midpoint_3d(v0, v1);
 
-    (midpoint_on_globe - midpoint_through_globe).length()
+    // The surface is always at distance 1.0 (sphere), so the error is the difference from that
+    (1.0 - midpoint.length()).abs()
 }
 
 /// Maps a geographical coordinate represented in radians onto a sphere

--- a/src/icosahedron.rs
+++ b/src/icosahedron.rs
@@ -20,7 +20,7 @@ pub fn icosahedron_vertices(subdivide_times: u8, scale: f32) -> Vec<Vertex> {
 }
 
 fn icosahedron_faces() -> Vec<Triangle> {
-    let latlong2xyz = |lat: f32, long: f32| crate::latlong2xyz(Coordinate { lat, long });
+    let latlong2xyz = |lat: f32, long: f32| crate::geo::latlong2xyz(Coordinate { lat, long });
 
     let mut triangles = Vec::with_capacity(20);
 


### PR DESCRIPTION
Compute if a line (triangle edge or contour line) needs to be split in two in a new way. Instead of using a hack estimate with angles, the code now instead use the actual distance from the earth's surface that the line shortcuts through the sphere.

This also moves `latlong2xyz` into the `geo` module. So a lot of the code is just about moving that and the related test.

The actual difference in the output data here is not large. I didn't do this to make the files smaller really. Just clean up the code and remove hacks/bad estimates. The resulting OpenGL buffer data is about the same, a tiny bit smaller. I don't even propose we update the actual data after merging this change. Doing so would add a lot of data to the main repo git history, for basically no tangible win.